### PR TITLE
Avoid sending prepared actor data to HeroVau.lt

### DIFF
--- a/herovault.js
+++ b/herovault.js
@@ -927,7 +927,7 @@ const exportPCtoHV = (
     else action = "importExistingPC";
 
     const gameSystem = game.data.system.id;
-    let pcEncodedJSON = encodeURIComponent(JSON.stringify(targetActor.data));
+    let pcEncodedJSON = encodeURIComponent(JSON.stringify(targetActor.toObject()));
     var xmlhttp = new XMLHttpRequest();
     xmlhttp.onreadystatechange = function () {
       if (this.readyState == 4 && this.status == 200) {


### PR DESCRIPTION
Data preparation fills a great number of data properties that are not intended to be stored and will cause issues when imported.